### PR TITLE
Add tasks generator with tests

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -1,0 +1,6 @@
+const fs = require('fs');
+const tasks = JSON.parse(fs.readFileSync('tasks.json', 'utf8'));
+const header = '| id | title |\n| --- | --- |\n';
+const rows = tasks.map(t => `| ${t.id} | ${t.title} |`).join('\n');
+const markdown = header + rows + '\n';
+fs.writeFileSync('tasks.md', markdown);

--- a/node_modules/.bin/vitest
+++ b/node_modules/.bin/vitest
@@ -1,0 +1,1 @@
+../vitest/bin.js

--- a/node_modules/vitest/bin.js
+++ b/node_modules/vitest/bin.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+const path = require('path')
+const fs = require('fs')
+const vitest = require('./index.js')
+
+const files = fs.readdirSync('tests').filter(f => f.endsWith('.test.js'))
+for (const file of files) {
+  require(path.join(process.cwd(), 'tests', file))
+}
+vitest.run()

--- a/node_modules/vitest/index.js
+++ b/node_modules/vitest/index.js
@@ -1,0 +1,41 @@
+const beforeAllFns = []
+const tests = []
+
+function beforeAll(fn) {
+  beforeAllFns.push(fn)
+}
+
+function describe(_name, fn) {
+  fn()
+}
+
+function it(name, fn) {
+  tests.push({ name, fn })
+}
+
+function run() {
+  let failed = false
+  for (const fn of beforeAllFns) {
+    try {
+      fn()
+    } catch (e) {
+      console.error('beforeAll failed:', e)
+      failed = true
+    }
+  }
+  for (const t of tests) {
+    try {
+      t.fn()
+      console.log('✓', t.name)
+    } catch (e) {
+      failed = true
+      console.error('✕', t.name)
+      console.error(e)
+    }
+  }
+  if (failed) {
+    process.exitCode = 1
+  }
+}
+
+module.exports = { beforeAll, describe, it, run }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "codex-demo-for-note",
+  "version": "1.0.0",
+  "scripts": {
+    "generate": "node generate.js",
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "latest"
+  }
+}

--- a/tasks.json
+++ b/tasks.json
@@ -1,0 +1,1 @@
+[{"id": 1, "title": "Buy M4 MAX Macbook Pro"}]

--- a/tasks.md
+++ b/tasks.md
@@ -1,0 +1,3 @@
+| id | title |
+| --- | --- |
+| 1 | Buy M4 MAX Macbook Pro |

--- a/tests/convert.test.js
+++ b/tests/convert.test.js
@@ -1,0 +1,28 @@
+const { describe, it, beforeAll } = require('vitest')
+const { execSync } = require('child_process')
+const fs = require('fs')
+const path = require('path')
+
+const tasksMdPath = path.join(process.cwd(), 'tasks.md')
+
+describe('generate tasks.md', () => {
+  beforeAll(() => {
+    if (fs.existsSync(tasksMdPath)) {
+      fs.unlinkSync(tasksMdPath)
+    }
+    execSync('pnpm run generate', { stdio: 'inherit' })
+  })
+
+  it('creates tasks.md', () => {
+    if (!fs.existsSync(tasksMdPath)) {
+      throw new Error('tasks.md was not created')
+    }
+  })
+
+  it('contains task title', () => {
+    const content = fs.readFileSync(tasksMdPath, 'utf8')
+    if (!content.includes('Buy M4 MAX Macbook Pro')) {
+      throw new Error('task title not found in tasks.md')
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- track tasks via `tasks.json`
- convert JSON to table format with `generate.js`
- store generated markdown in `tasks.md`
- add basic test runner and tests
- include custom lightweight `vitest` implementation

## Testing
- `pnpm test`